### PR TITLE
Accessibility update and tracking to Matomo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "lodash.get": "^4.4.2",
-    "losen": "^5.1.10",
+    "losen": "^6.0.0",
     "prop-types": "^15.6.2",
     "react": "^15.6.1",
     "react-autobind": "^1.0.6",

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ class App extends Component {
   closeIntro = () => {
     this.setState({ intro: false });
     window.scrollTo(0, 0);
-    trackEvent('close-intro');
+    trackEvent('Close intro');
   }
 
   showIntro = () => {


### PR DESCRIPTION
Updated losen to version 6.0.0 that includes [accessibility fixes for WCAG 2.1](https://github.com/DirektoratetForByggkvalitet/losen/pull/186) and [replace Google Analytics tracking with Matomo](https://github.com/DirektoratetForByggkvalitet/losen/pull/185).